### PR TITLE
記事詳細ページと本文コンテナのスタイルを整理する

### DIFF
--- a/app/pages/[...slug].vue
+++ b/app/pages/[...slug].vue
@@ -31,44 +31,16 @@ useSeoMeta({
 </script>
 
 <template>
-  <div class="container">
-    <ContentRenderer v-if="article" :value="article" />
-  </div>
+  <main
+    class="min-h-[calc(100svh-var(--ui-header-height))] bg-[var(--jwp-color-background)] py-2 sm:py-4 lg:py-6"
+  >
+    <UContainer>
+      <ContentRenderer
+        v-if="article"
+        :value="article"
+        tag="article"
+        class="mx-auto w-full max-w-4xl"
+      />
+    </UContainer>
+  </main>
 </template>
-
-<style scoped lang="scss">
-.container {
-  display: flex;
-  justify-content: center;
-  padding-left: 5%;
-  padding-right: 5%;
-  padding-top: 1%;
-  max-width: 100%;
-  box-sizing: border-box;
-}
-
-/* タブレット以下のサイズ */
-@media screen and (max-width: 800px) {
-  .container {
-    padding-left: 3%;
-    padding-right: 3%;
-  }
-}
-
-/* モバイルサイズ */
-@media screen and (max-width: 600px) {
-  .container {
-    padding-left: 2%;
-    padding-right: 2%;
-    padding-top: 2%;
-  }
-}
-
-/* 小さなモバイルサイズ */
-@media screen and (max-width: 480px) {
-  .container {
-    padding-left: 1%;
-    padding-right: 1%;
-  }
-}
-</style>


### PR DESCRIPTION
## Summary
- `app/pages/[...slug].vue` の本文コンテナを `UContainer` ベースへ寄せて、ページ固有の余白・幅調整を template 側へ整理した
- 記事詳細ページに `main` の最小高さと背景を持たせ、本文コンテナ周辺のレイアウト責務をページ側に明確化した
- 旧 scoped CSS のコンテナ定義を削除し、グローバル content スタイルとページ固有レイアウトを分離した

## Test plan
- [x] `pnpm build`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure layout/styling refactor limited to the article detail page; no changes to data fetching, routing, or SEO logic.
> 
> **Overview**
> Refactors `app/pages/[...slug].vue` to move article-page layout concerns into the template: wraps content in a `main` with min-height/background/padding utilities and renders the `ContentRenderer` as an `article` with a max width.
> 
> Removes the old `.container` wrapper and all page-scoped responsive SCSS, standardizing spacing on `UContainer`/utility classes instead.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88086f977dba3b2b73db91cef568465c3ed33448. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->