### PR TITLE
グローバル CSS と scoped CSS を棚卸しして削減する

### DIFF
--- a/app/assets/style/index.css
+++ b/app/assets/style/index.css
@@ -64,6 +64,8 @@
 /* 記事本文に残すコンテンツ補正 */
 .article-content {
   max-width: 100% !important;
+  overflow-x: auto;
+  word-wrap: break-word;
   box-sizing: border-box;
 }
 

--- a/app/assets/style/index.css
+++ b/app/assets/style/index.css
@@ -1,4 +1,3 @@
-@import url(https://fonts.googleapis.com/icon?family=Material+Icons);
 @import "tailwindcss";
 @import "@nuxt/ui";
 
@@ -62,17 +61,15 @@
   margin: 0;
 }
 
-/* Nuxt Content を使う間は global に残すレイアウト補正 */
-[class*="content:"] {
+/* 記事本文に残すコンテンツ補正 */
+.article-content {
   max-width: 100% !important;
-  overflow-x: auto;
-  word-wrap: break-word;
   box-sizing: border-box;
 }
 
 /* コードブロック */
-pre,
-pre code {
+.article-content pre,
+.article-content pre code {
   max-width: 100%;
   overflow-x: auto;
   white-space: pre-wrap;
@@ -81,7 +78,7 @@ pre code {
 }
 
 /* インラインコード */
-code:not(pre code) {
+.article-content code:not(pre code) {
   white-space: normal;
   word-break: normal;
   overflow-wrap: normal;
@@ -92,7 +89,7 @@ code:not(pre code) {
 }
 
 /* テーブル */
-table {
+.article-content table {
   width: 100% !important;
   max-width: 100% !important;
   overflow-x: auto !important;
@@ -102,20 +99,20 @@ table {
 
 /* モバイル専用のコンテンツスタイル */
 @media screen and (max-width: 600px) {
-  [class*="content:"] {
+  .article-content {
     font-size: 12px !important;
     line-height: 1.4 !important;
   }
 
-  pre,
-  pre code {
+  .article-content pre,
+  .article-content pre code {
     font-size: 10px !important;
     padding: 8px !important;
     margin: 4px 0 !important;
   }
 
   /* 非常に長い文字列も強制的に改行 */
-  * {
+  .article-content * {
     word-break: break-word !important;
     overflow-wrap: break-word !important;
     hyphens: auto !important;
@@ -123,96 +120,29 @@ table {
 }
 
 @media screen and (max-width: 480px) {
-  [class*="content:"] {
+  .article-content {
     font-size: 10px !important;
   }
 
-  pre,
-  pre code {
+  .article-content pre,
+  .article-content pre code {
     font-size: 9px !important;
     padding: 6px !important;
   }
 }
 
-/* 個別コンポーネント置換まで残す既存アニメーション群 */
-.animation-bg {
-  z-index: 999;
-}
-@keyframes PageAnime-rtl {
-  0% {
-    transform-origin: right;
-    transform: scaleX(0);
-  }
-  50% {
-    transform-origin: right;
-    transform: scaleX(1);
-  }
-  50.001% {
-    transform-origin: left;
-  }
-  100% {
-    transform-origin: left;
-    transform: scaleX(0);
-  }
-}
-@keyframes PageAnime-ltr {
-  0% {
-    transform-origin: left;
-    transform: scaleX(0);
-  }
-  50% {
-    transform-origin: left;
-    transform: scaleX(1);
-  }
-  50.001% {
-    transform-origin: right;
-  }
-  100% {
-    transform-origin: right;
-    transform: scaleX(0);
-  }
-}
-
-.transition {
-  position: absolute;
-  /* height:100%; */
-  width: 0%;
-  z-index: 999;
-  background: var(--jwp-color-header);
-  transform: skewX(0deg) translateX(-50px);
-  transition: 0.3s all ease-in-out;
-  -webkit-transition: 0.3s all ease-in-out;
-}
-
-.content {
-  position: relative;
-  z-index: 990;
-}
-
-.cta {
-  outline: none;
-  border: none;
-  text-decoration: none;
-  text-transform: uppercase;
-  box-sizing: border-box;
-  margin-top: 20px;
-  padding: 10px 40px;
-}
-
-.anim-trans {
-  animation: anim 0.5s ease-in-out;
-}
-
 body {
   background-color: var(--jwp-color-background);
   color: var(--jwp-color-text);
+  margin: 0;
+  padding: 0;
   /** font kerning */
   font-feature-settings: "palt";
   letter-spacing: 0.1rem;
   /** 行間  */
   line-height: .8rem;
 }
-a {
+.article-content a {
   margin: 0;
   padding: 0;
   vertical-align: baseline;
@@ -226,160 +156,104 @@ a {
       transition: 0.5s;
       color: white; */
 }
-a:hover {
+
+.article-content a:hover {
   color: var(--jwp-color-link-hover);
 }
-a:active {
+
+.article-content a:active {
   color: var(--jwp-color-link-active);
 }
 
-h1,
-h2,
-h3,
-h4,
-h5 {
+.article-content h1,
+.article-content h2,
+.article-content h3,
+.article-content h4,
+.article-content h5 {
   padding-top: 2rem;
 }
 
 @media screen and (max-width: 600px) {
-  h1,
-  h2,
-  h3,
-  h4,
-  h5 {
+  .article-content h1,
+  .article-content h2,
+  .article-content h3,
+  .article-content h4,
+  .article-content h5 {
     padding-top: 1rem;
   }
 }
 
-h1 {
+.article-content h1 {
   border-bottom: double 6px var(--jwp-color-text);
 }
-h2 > a {
+
+.article-content h2 > a {
   border-bottom: double 6px var(--jwp-color-text);
 }
-h2 > a,
-h3 > a,
-h4 > a {
+
+.article-content h2 > a,
+.article-content h3 > a,
+.article-content h4 > a {
   color: var(--jwp-color-text);
 }
 
 @media screen and (max-width: 800px) {
-  h1 {
+  .article-content h1 {
     font-size: 30px;
     padding-top: 3%;
   }
 }
 @media screen and (max-width: 600px) {
-  h1 {
+  .article-content h1 {
     font-size: 24px;
     padding-top: 3%;
   }
-  h2 {
+
+  .article-content h2 {
     font-size: 16px;
     padding-top: 3%;
   }
-  h3 {
+
+  .article-content h3 {
     font-size: 14px;
     padding-top: 3%;
   }
-  p,
-  div,
-  span,
-  ul,
-  li {
+
+  .article-content p,
+  .article-content div,
+  .article-content span,
+  .article-content ul,
+  .article-content li {
     font-size: 12px;
   }
 }
 @media screen and (max-width: 480px) {
-  h1 {
+  .article-content h1 {
     font-size: 20px;
     padding-top: 3%;
   }
-  h2 {
+
+  .article-content h2 {
     font-size: 16px;
     padding-top: 3%;
   }
-  h3 {
+
+  .article-content h3 {
     font-size: 12px;
     padding-top: 3%;
   }
-  p,
-  div,
-  span,
-  ul,
-  li {
+
+  .article-content p,
+  .article-content div,
+  .article-content span,
+  .article-content ul,
+  .article-content li {
     font-size: 10px;
   }
 }
 
-@keyframes anim {
-  0% {
-    transform: translateX(0);
-    width: 100%;
-    z-index: 999;
-    box-shadow: 10px 10px 10px #eaeaea;
-  }
-  60% {
-    z-index: 999;
-    transform: translateX(-10%);
-  }
-  100% {
-  }
-}
-
-.animation-bg {
-  z-index: 999;
-}
-@keyframes PageAnime-rtl {
-  0% {
-    transform-origin: right;
-    transform: scaleX(0);
-  }
-  50% {
-    transform-origin: right;
-    transform: scaleX(1);
-  }
-  50.001% {
-    transform-origin: left;
-  }
-  100% {
-    transform-origin: left;
-    transform: scaleX(0);
-  }
-}
-@keyframes PageAnime-ltr {
-  0% {
-    transform-origin: left;
-    transform: scaleX(0);
-  }
-  50% {
-    transform-origin: left;
-    transform: scaleX(1);
-  }
-  50.001% {
-    transform-origin: right;
-  }
-  100% {
-    transform-origin: right;
-    transform: scaleX(0);
-  }
-}
-
-.transition {
-  position: absolute;
-  /* height:100%; */
-  width: 0%;
-  z-index: 999;
-  background: var(--jwp-color-header);
-  transform: skewX(0deg) translateX(-50px);
-  transition: 0.3s all ease-in-out;
-  -webkit-transition: 0.3s all ease-in-out;
-}
-
 html,
 body {
-  margin: 0;
-  padding: 0;
   background-color: var(--jwp-color-background);
   color: var(--jwp-color-text);
 }

--- a/app/components/Callout.vue
+++ b/app/components/Callout.vue
@@ -10,38 +10,3 @@
     </div>
   </div>
 </template>
-<style scoped>
-.bg-white {
-  background-color: #fff;
-}
-.shadow {
-  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
-}
-.overflow-hidden {
-  overflow: hidden;
-}
-.sm\:rounded-lg {
-  border-radius: 0.5rem;
-}
-.px-4 {
-  padding-left: 1rem;
-  padding-right: 1rem;
-}
-.py-5 {
-  padding-top: 1.25rem;
-  padding-bottom: 1.25rem;
-}
-.sm\:px-6 {
-  padding-left: 1.5rem;
-  padding-right: 1.5rem;
-}
-.text-lg {
-  font-size: 1.125rem;
-}
-.font-medium {
-  font-weight: 500;
-}
-.text-gray-900 {
-  color: #1a202c;
-}
-</style>

--- a/app/components/Header.vue
+++ b/app/components/Header.vue
@@ -86,7 +86,7 @@ const mobileNavigationUi = {
           variant="link"
           :ui="desktopNavigationUi"
         />
-        <SelectLang class="w-32 mt-auto mb-1" />
+        <SelectLang class="w-32" />
       </div>
     </template>
 

--- a/app/components/HomeIcon.vue
+++ b/app/components/HomeIcon.vue
@@ -18,27 +18,18 @@
 </script>
 
 <template>
-  <div class="home-icon">
+  <div
+    class="grid place-items-center"
+    :style="{ width: props.width, height: props.height }"
+  >
     <img
       v-if="!loading"
       src="/icon-72x72.png"
       type="image/png"
       width="1px"
       height="1px"
+      class="rounded-full"
+      :style="{ width: props.width, height: props.height }"
     />
   </div>
 </template>
-
-<style scoped>
-  .home-icon {
-    display: grid;
-    place-items: center;
-    width: v-bind(props.width); /* ※縦横を同値に */
-    height: v-bind(props.height); /* ※縦横を同値に */
-  }
-  img {
-    border-radius: 50%; /* 角丸半径を50%にする(=円形にする) */
-    width: v-bind(props.width); /* ※縦横を同値に */
-    height: v-bind(props.height); /* ※縦横を同値に */
-  }
-</style>

--- a/app/components/ProfilePageContent.vue
+++ b/app/components/ProfilePageContent.vue
@@ -20,7 +20,7 @@ setTimeout(() => {
 
 <template>
   <main class="min-h-[calc(100svh-var(--ui-header-height))] bg-[var(--jwp-color-background)]">
-    <div class="transition" :class="{ 'anim-trans': trans }"></div>
+    <div class="page-transition" :class="{ 'anim-trans': trans }"></div>
 
     <UContainer class="py-6 sm:py-8">
       <section class="space-y-4 sm:space-y-6">
@@ -68,3 +68,34 @@ setTimeout(() => {
     </UContainer>
   </main>
 </template>
+
+<style scoped>
+.page-transition {
+  position: absolute;
+  width: 0%;
+  z-index: 999;
+  background: var(--jwp-color-header);
+  transform: skewX(0deg) translateX(-50px);
+  transition: 0.3s all ease-in-out;
+  -webkit-transition: 0.3s all ease-in-out;
+}
+
+.anim-trans {
+  animation: anim 0.5s ease-in-out;
+}
+
+@keyframes anim {
+  0% {
+    transform: translateX(0);
+    width: 100%;
+    z-index: 999;
+    box-shadow: 10px 10px 10px #eaeaea;
+  }
+  60% {
+    z-index: 999;
+    transform: translateX(-10%);
+  }
+  100% {
+  }
+}
+</style>

--- a/app/pages/[...slug].vue
+++ b/app/pages/[...slug].vue
@@ -39,7 +39,7 @@ useSeoMeta({
         v-if="article"
         :value="article"
         tag="article"
-        class="mx-auto w-full max-w-4xl"
+        class="article-content mx-auto w-full max-w-4xl"
       />
     </UContainer>
   </main>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -10,11 +10,3 @@
   <main>
   </main>
 </template>
-
-<style scoped>
-  .article {
-    margin-left: 3%;
-    margin-right: 3%;
-    margin-top: 3%;
-  }
-</style>


### PR DESCRIPTION
## Summary
- `app/assets/style/index.css` のうち記事本文専用のルールを `.article-content` 配下へ寄せて、グローバルに漏れていたタイポグラフィと content 補正の責務を整理した
- 未使用または重複していた旧アニメーション / utility 再実装 / dead scoped CSS を削除し、NuxtUI 置き換え後の CSS 依存を減らした
- `ProfilePageContent.vue` に残すべきページ遷移アニメーションだけを component scoped へ戻し、ページ固有スタイルと global スタイルを切り分けた

## Test plan
- [x] `pnpm build`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly CSS scoping/cleanup, but changing selectors from global to `.article-content` can subtly alter typography/layout on pages that previously relied on global leakage.
> 
> **Overview**
> **Reduces global CSS leakage** by moving content/typography/overflow fixes (tables, code blocks, headings, links, mobile font sizing) under `.article-content` and applying that class to the article renderer in `[...slug].vue`.
> 
> **Prunes unused or duplicated CSS** by deleting legacy global animation/utility rules and removing dead scoped styles in components (`Callout.vue`, `HomeIcon.vue`, `index.vue`), while keeping the profile page transition by renaming `transition` to `page-transition` and reintroducing the animation as scoped CSS in `ProfilePageContent.vue`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b28ea95dc65fe3d34778952adc3ca61d6d839c15. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->