### PR TITLE
fix: 🐛 use Vercel-compatible Node 24 engine range

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
     "tailwindcss": "^4.2.1"
   },
   "engines": {
-    "node": "^24.0.0"
+    "node": "24.x"
   }
 }


### PR DESCRIPTION
## Summary
- switch `package.json` to use `24.x` for `engines.node`
- keep the project on Node 24 while matching the version format Vercel accepts for builds and deployments
- remove the invalid Node.js version warning from the Vercel CLI flow

## Test plan
- [x] `pnpm build`
- [x] `vercel whoami`
- [x] `git diff master...HEAD`

Made with [Cursor](https://cursor.com)