### PR TITLE
fix: 🐛 restore article list page titles

### DIFF
--- a/app/pages/en/index.vue
+++ b/app/pages/en/index.vue
@@ -1,10 +1,6 @@
 <script setup lang="ts">
 import ArticleListPage from "~/components/ArticleListPage.vue";
 const { articles } = await useArticlesByLocale("en", { limit: 15 });
-
-useHead({
-  title: "",
-});
 </script>
 
 <template>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,9 +1,6 @@
 <script setup lang="ts">
-  useHead({
-    title: "",
-  });
-  const router = useRouter();
-  router.replace("/en");
+const router = useRouter();
+router.replace("/en");
 </script>
 
 <template>

--- a/app/pages/ja/index.vue
+++ b/app/pages/ja/index.vue
@@ -1,10 +1,6 @@
 <script setup lang="ts">
 import ArticleListPage from "~/components/ArticleListPage.vue";
 const { articles } = await useArticlesByLocale("ja");
-
-useHead({
-  title: "",
-});
 </script>
 
 <template>


### PR DESCRIPTION
## Summary
- remove the empty page title overrides from the article list routes
- let the article list pages fall back to the app's default title instead of rendering as untitled tabs
- apply the same cleanup to the redirecting root page for consistency

## Test plan
- [x] `pnpm build`
- [x] `git diff master...HEAD`
- [x] verified the article list routes no longer override the title with an empty string

Made with [Cursor](https://cursor.com)